### PR TITLE
Try to use the new MySQL driver first.

### DIFF
--- a/Common/src/main/java/dev/brighten/antivpn/database/sql/utils/MySQL.java
+++ b/Common/src/main/java/dev/brighten/antivpn/database/sql/utils/MySQL.java
@@ -12,7 +12,7 @@ public class MySQL {
     public static void init() {
         try {
             if (conn == null || conn.isClosed()) {
-                Class.forName("com.mysql.jdbc.Driver");
+                Class.forName("com.mysql.cj.jdbc.Driver");
                 conn = DriverManager.getConnection("jdbc:mysql://" + AntiVPN.getInstance().getConfig().getIp()
                                 + ":" + AntiVPN.getInstance().getConfig().getPort()
                                 + "/?useSSL=true&autoReconnect=true",

--- a/Common/src/main/java/dev/brighten/antivpn/database/sql/utils/MySQL.java
+++ b/Common/src/main/java/dev/brighten/antivpn/database/sql/utils/MySQL.java
@@ -12,7 +12,11 @@ public class MySQL {
     public static void init() {
         try {
             if (conn == null || conn.isClosed()) {
-                Class.forName("com.mysql.cj.jdbc.Driver");
+                try {
+                    Class.forName("com.mysql.cj.jdbc.Driver");
+                } catch (ClassNotFoundException e) {
+                    Class.forName("com.mysql.jdbc.Driver");
+                }
                 conn = DriverManager.getConnection("jdbc:mysql://" + AntiVPN.getInstance().getConfig().getIp()
                                 + ":" + AntiVPN.getInstance().getConfig().getPort()
                                 + "/?useSSL=true&autoReconnect=true",


### PR DESCRIPTION
Removes the MySQL driver warning when starting the server by trying to use the new driver first.

```
06:10:38 [INFO] Loading config...
06:10:38 [INFO] Starting AntiVPN services...
06:10:38 [INFO] Using databaseType MySQL...
06:10:38 [INFO] Initializing MySQL...
06:10:38 [SEVERE] Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.
```