### PR TITLE
attempted fix of wrong alert state

### DIFF
--- a/Bukkit/src/main/java/dev/brighten/antivpn/bukkit/BukkitPlayerExecutor.java
+++ b/Bukkit/src/main/java/dev/brighten/antivpn/bukkit/BukkitPlayerExecutor.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 public class BukkitPlayerExecutor implements PlayerExecutor {
 
-    private final Map<Player, BukkitPlayer> cachedPlayers = new WeakHashMap<>();
+    private final Map<UUID, BukkitPlayer> cachedPlayers = new WeakHashMap<>();
 
     @Override
     public Optional<APIPlayer> getPlayer(String name) {
@@ -21,7 +21,7 @@ public class BukkitPlayerExecutor implements PlayerExecutor {
             return Optional.empty();
         }
 
-        return Optional.of(cachedPlayers.computeIfAbsent(player, BukkitPlayer::new));
+        return Optional.of(cachedPlayers.getOrDefault(player.getUniqueId(), new BukkitPlayer(player)));
     }
 
     @Override
@@ -32,14 +32,14 @@ public class BukkitPlayerExecutor implements PlayerExecutor {
             return Optional.empty();
         }
 
-        return Optional.of(cachedPlayers.computeIfAbsent(player, BukkitPlayer::new));
+        return Optional.of(cachedPlayers.getOrDefault(player.getUniqueId(), new BukkitPlayer(player)));
     }
 
 
     @Override
     public List<APIPlayer> getOnlinePlayers() {
         return Bukkit.getOnlinePlayers().stream()
-                .map(pl -> cachedPlayers.computeIfAbsent(pl, BukkitPlayer::new))
+                .map(pl -> cachedPlayers.getOrDefault(pl.getUniqueId(), new BukkitPlayer(pl)))
                 .collect(Collectors.toList());
     }
 

--- a/Bukkit/src/main/java/dev/brighten/antivpn/bukkit/BukkitPlayerExecutor.java
+++ b/Bukkit/src/main/java/dev/brighten/antivpn/bukkit/BukkitPlayerExecutor.java
@@ -21,7 +21,7 @@ public class BukkitPlayerExecutor implements PlayerExecutor {
             return Optional.empty();
         }
 
-        return Optional.of(cachedPlayers.getOrDefault(player.getUniqueId(), new BukkitPlayer(player)));
+        return Optional.of(cachedPlayers.computeIfAbsent(player.getUniqueId(), k -> new BukkitPlayer(player)));
     }
 
     @Override
@@ -32,14 +32,14 @@ public class BukkitPlayerExecutor implements PlayerExecutor {
             return Optional.empty();
         }
 
-        return Optional.of(cachedPlayers.getOrDefault(player.getUniqueId(), new BukkitPlayer(player)));
+        return Optional.of(cachedPlayers.computeIfAbsent(player.getUniqueId(), k -> new BukkitPlayer(player)));
     }
 
 
     @Override
     public List<APIPlayer> getOnlinePlayers() {
         return Bukkit.getOnlinePlayers().stream()
-                .map(pl -> cachedPlayers.getOrDefault(pl.getUniqueId(), new BukkitPlayer(pl)))
+                .map(pl -> cachedPlayers.computeIfAbsent(pl.getUniqueId(), k -> new BukkitPlayer(pl)))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
**## WARNING: This is untested code. Please test it on a test server before proceeding. ##**

Fixed the caching to use UUIDs as key and not Player objects. The player objects desyncronize on rejoining the server and therefore have to be replaced by UUIDs. I dont know if the code works, it is only an edit on first sight to highlight the issues possible solution. Please test and refactor the code as needed.