### PR TITLE
Correct ISO codes link in config

### DIFF
--- a/Common/src/main/resources/config.yml
+++ b/Common/src/main/resources/config.yml
@@ -50,7 +50,7 @@ alerts:
     &7in location &8(&f%city%&7, &f%country%&8)'
 # Configuration for country gatekeepings
 countries:
-  # You must use ISO codes for country configuration: https://www.iban.com/country-code
+  # You must use ISO codes for country configuration: https://www.iban.com/country-codes
   # Leave empty to disable this configuration
   list: []
   # Set whitelist to true to only allow listed country codes, and false to deny listed country codes.


### PR DESCRIPTION
Simple link change from [the old link](https://www.iban.com/country-code) to [the new link](https://www.iban.com/country-codes). The old link resolves to a 404